### PR TITLE
Add logging of path to keypair file

### DIFF
--- a/cmd/udiglink/main.go
+++ b/cmd/udiglink/main.go
@@ -177,7 +177,7 @@ func ensureKeypair(keyPairFile string) (ed25519.PublicKey, ed25519.PrivateKey, e
 			return nil, nil, errors.Trace(err)
 		}
 	}
-	glog.Infof("using key file: %s", keyPairFile)
+	fmt.Fprintf(os.Stderr, "using key file: %s\n", keyPairFile)
 	return keypair.Public, keypair.Private, nil
 }
 

--- a/cmd/udiglink/main.go
+++ b/cmd/udiglink/main.go
@@ -177,6 +177,7 @@ func ensureKeypair(keyPairFile string) (ed25519.PublicKey, ed25519.PrivateKey, e
 			return nil, nil, errors.Trace(err)
 		}
 	}
+	glog.Infof("using key file: %s", keyPairFile)
 	return keypair.Public, keypair.Private, nil
 }
 


### PR DESCRIPTION
I consider knowing where the keys are makes it a better experience when getting started with `udig`.
